### PR TITLE
Add settings.ROUND_PIXELS = true;

### DIFF
--- a/packages/client/src/game/Game.ts
+++ b/packages/client/src/game/Game.ts
@@ -13,6 +13,7 @@ import { distanceBetween } from './utils/distance';
 
 // We don't want to scale textures linearly because they would appear blurry.
 settings.SCALE_MODE = SCALE_MODES.NEAREST;
+settings.ROUND_PIXELS = true;
 
 const ZINDEXES = {
     GROUND: 1,


### PR DESCRIPTION
Advantage of having this is that if you were to ever want to use tiles of a different size and scale them to Constants.TILE_SIZE you could do so with this and still not have black outlines surrounding where tiles meet.

Downside: as far as I can tell none when it comes to using big pixelated sprites (as Tosios does).  Might make some animations less smooth?  I haven't noticed anything in my testing so far.